### PR TITLE
expired_in? method 

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -72,6 +72,13 @@ module OAuth2
       expires? && (expires_at < Time.now.to_i)
     end
 
+    # Whether or not the token is expired in next 'seconds' seconds
+    #
+    # @return [Boolean]
+    def expired_in?(seconds)
+      expires? && (expires_at < Time.now.to_i + seconds.to_i)
+    end
+
     # Refreshes the current Access Token
     #
     # @return [AccessToken] a new AccessToken


### PR DESCRIPTION
Developers usually check .expired? method but it works in a very straightforward manner and doesn't check e.g. will the token be expired in the next couple of seconds. It causes like 0.1-1% failed requests for normal and delayed jobs, not synced unix time because there is always slight network legacy between expired? check and its usage.

```
if token.expired_in? 3.minutes
  refresh_token
end
delayed_queue.push job
```