### PR TITLE
Convert ISO 8601 expires_at to integer

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -44,6 +44,10 @@ module OAuth2
       end
       @expires_in ||= opts.delete('expires')
       @expires_in &&= @expires_in.to_i
+      
+      if @expires_at.kind_of?(String) && !(@expires_at =~ /^[1-9]\d*(\.\d+)?$/)
+        @expires_at = Time.parse(@expires_at)
+      end
       @expires_at &&= @expires_at.to_i
       @expires_at ||= Time.now.to_i + @expires_in if @expires_in
       @options = {:mode          => opts.delete(:mode) || :header,

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -63,6 +63,14 @@ describe AccessToken do
       assert_initialized_token(target)
       expect(target.expires_at).to be_a(Integer)
     end
+
+    it 'initializes with a iso8601 string expires_at' do
+      expires = Time.now
+      hash = {:access_token => token, :expires_at => expires.iso8601, 'foo' => 'bar'}
+      target = AccessToken.from_hash(client, hash)
+      assert_initialized_token(target)
+      expect(target.expires_at).to eq(expires.to_i)
+    end
   end
 
   describe '#request' do


### PR DESCRIPTION
I'm attempting to use Omniauth w/ [Square's API](https://connect.squareup.com/docs/api#post-token). Unfortunately, Square provides expires_at as an ISO 8601 string, so when `@expires_at.to_i` is called, the expires at is set as 2014.

I wrote a workaround for danieljacobarcher/omniauth-square#2, but it's pretty ugly because it requires fetching the access token without using the get_token method. It would be best if the underlying oauth2 gem supported parsing ISO8601 timestamps.