### PR TITLE
auth_code: default to header based authorization

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'logger'
+require 'byebug'
 
 module OAuth2
   # The OAuth2::Client class
@@ -19,6 +20,7 @@ module OAuth2
     # @option opts [String] :authorize_url ('/oauth/authorize') absolute or relative URL path to the Authorization endpoint
     # @option opts [String] :token_url ('/oauth/token') absolute or relative URL path to the Token endpoint
     # @option opts [Symbol] :token_method (:post) HTTP method to use to request token (:get or :post)
+    # @option opts [Symbol] :auth_scheme (:basic_auth) HTTP method to use to authorize request (:basic_auth or :request_body)
     # @option opts [Hash] :connection_opts ({}) Hash of connection options to pass to initialize Faraday with
     # @option opts [FixNum] :max_redirects (5) maximum number of redirects to follow
     # @option opts [Boolean] :raise_errors (true) whether or not to raise an OAuth2::Error
@@ -33,6 +35,7 @@ module OAuth2
       @options = {:authorize_url    => '/oauth/authorize',
                   :token_url        => '/oauth/token',
                   :token_method     => :post,
+                  :auth_scheme      => :basic_auth,
                   :connection_opts  => {},
                   :connection_build => block,
                   :max_redirects    => 5,

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -127,14 +127,15 @@ module OAuth2
     # @return [AccessToken] the initalized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}
+      headers = params.delete(:headers)
       if options[:token_method] == :post
-        headers = params.delete(:headers)
         opts[:body] = params
-        opts[:headers] =  {'Content-Type' => 'application/x-www-form-urlencoded'}
-        opts[:headers].merge!(headers) if headers
+        opts[:headers] = {'Content-Type' => 'application/x-www-form-urlencoded'}
       else
         opts[:params] = params
+        opts[:headers] = {}
       end
+      opts[:headers].merge!(headers) if headers
       response = request(options[:token_method], token_url, opts)
       error = Error.new(response)
       fail(error) if options[:raise_errors] && !(response.parsed.is_a?(Hash) && response.parsed['access_token'])

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -1,6 +1,5 @@
 require 'faraday'
 require 'logger'
-require 'byebug'
 
 module OAuth2
   # The OAuth2::Client class

--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -25,11 +25,7 @@ module OAuth2
       # @param [Hash] opts options
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
       def get_token(code, params = {}, opts = {})
-        request_body = opts.delete('auth_scheme') == 'request_body'
-        params.merge!('grant_type' => 'authorization_code', 'code' => code)
-        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
-        params.merge!(params)
-
+        params = {'grant_type' => 'authorization_code', 'code' => code}.merge(client_params).merge(params)
         @client.get_token(params, opts)
       end
     end

--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -25,7 +25,11 @@ module OAuth2
       # @param [Hash] opts options
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
       def get_token(code, params = {}, opts = {})
-        params = {'grant_type' => 'authorization_code', 'code' => code}.merge(client_params).merge(params)
+        request_body = opts.delete('auth_scheme') == 'request_body'
+        params.merge!('grant_type' => 'authorization_code', 'code' => code)
+        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
+        params.merge!(params)
+
         @client.get_token(params, opts)
       end
     end

--- a/lib/oauth2/strategy/base.rb
+++ b/lib/oauth2/strategy/base.rb
@@ -11,6 +11,14 @@ module OAuth2
       def client_params
         {'client_id' => @client.id, 'client_secret' => @client.secret}
       end
+
+      # Returns the Authorization header value for Basic Authentication
+      #
+      # @param [String] The client ID
+      # @param [String] the client secret
+      def authorization(client_id, client_secret)
+        'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub("\n", '')
+      end
     end
   end
 end

--- a/lib/oauth2/strategy/base.rb
+++ b/lib/oauth2/strategy/base.rb
@@ -9,7 +9,12 @@ module OAuth2
       #
       # @return [Hash]
       def client_params
-        {'client_id' => @client.id, 'client_secret' => @client.secret}
+        case @client.options[:auth_scheme]
+        when :request_body
+          {'client_id' => @client.id, 'client_secret' => @client.secret}
+        when :basic_auth
+          {:headers => {'Authorization' => authorization(@client.id, @client.secret)}}
+        end
       end
 
       # Returns the Authorization header value for Basic Authentication

--- a/lib/oauth2/strategy/base.rb
+++ b/lib/oauth2/strategy/base.rb
@@ -12,7 +12,7 @@ module OAuth2
         case @client.options[:auth_scheme]
         when :request_body
           {'client_id' => @client.id, 'client_secret' => @client.secret}
-        when :basic_auth
+        else
           {:headers => {'Authorization' => authorization(@client.id, @client.secret)}}
         end
       end

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -18,9 +18,7 @@ module OAuth2
       # @param [Hash] params additional params
       # @param [Hash] opts options
       def get_token(params = {}, opts = {})
-        request_body = opts.delete('auth_scheme') == 'request_body'
-        params.merge!('grant_type' => 'client_credentials')
-        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
+        params = {'grant_type' => 'client_credentials'}.merge(client_params).merge(params)
         @client.get_token(params, opts.merge('refresh_token' => nil))
       end
     end

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -23,14 +23,6 @@ module OAuth2
         params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
         @client.get_token(params, opts.merge('refresh_token' => nil))
       end
-
-      # Returns the Authorization header value for Basic Authentication
-      #
-      # @param [String] The client ID
-      # @param [String] the client secret
-      def authorization(client_id, client_secret)
-        'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub("\n", '')
-      end
     end
   end
 end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -81,6 +81,13 @@ describe OAuth2::Client do
       expect(client.options[:access_token_method]).to eq(:post)
     end
 
+    it 'allows basic_auth/request_body for auth_scheme option' do
+      client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :basic_auth)
+      expect(client.options[:auth_scheme]).to eq(:basic_auth)
+      client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body)
+      expect(client.options[:auth_scheme]).to eq(:request_body)
+    end
+
     it 'does not mutate the opts hash argument' do
       opts = {:site => 'http://example.com/'}
       opts2 = opts.dup

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -29,6 +29,30 @@ describe OAuth2::Strategy::AuthCode do
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, facebook_token]
           end
         end
+        stub.get("/oauth/token?code=#{code}&grant_type=authorization_code") do |env|
+          client_id, client_secret = Base64.decode64(env[:request_headers]['Authorization'].split(' ', 2)[1]).split(':', 2)
+          client_id == 'abc' && client_secret == 'def' || fail(Faraday::Adapter::Test::Stubs::NotFound)
+          case @mode
+          when 'formencoded'
+            [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]
+          when 'json'
+            [200, {'Content-Type' => 'application/json'}, json_token]
+          when 'from_facebook'
+            [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, facebook_token]
+          end
+        end
+        stub.post('/oauth/token', 'code' => 'sushi', 'grant_type' => 'authorization_code') do |env|
+          client_id, client_secret = Base64.decode64(env[:request_headers]['Authorization'].split(' ', 2)[1]).split(':', 2)
+          client_id == 'abc' && client_secret == 'def' || fail(Faraday::Adapter::Test::Stubs::NotFound)
+          case @mode
+          when 'formencoded'
+            [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]
+          when 'json'
+            [200, {'Content-Type' => 'application/json'}, json_token]
+          when 'from_facebook'
+            [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, facebook_token]
+          end
+        end
       end
     end
   end
@@ -51,36 +75,38 @@ describe OAuth2::Strategy::AuthCode do
   end
 
   %w(json formencoded from_facebook).each do |mode|
-    [:get, :post].each do |verb|
-      describe "#get_token (#{mode}, access_token_method=#{verb}" do
-        before do
-          @mode = mode
-          client.options[:token_method] = verb
-          @access = subject.get_token(code)
-        end
+    %w(default basic_auth request_body).each do |auth_scheme|
+      [:get, :post].each do |verb|
+        describe "#get_token (#{mode}, access_token_method=#{verb}, auth_scheme=#{auth_scheme})" do
+          before do
+            @mode = mode
+            client.options[:token_method] = verb
+            @access = subject.get_token(code, {}, auth_scheme == 'default' ? {} : {'auth_scheme' => auth_scheme})
+          end
 
-        it 'returns AccessToken with same Client' do
-          expect(@access.client).to eq(client)
-        end
+          it 'returns AccessToken with same Client' do
+            expect(@access.client).to eq(client)
+          end
 
-        it 'returns AccessToken with #token' do
-          expect(@access.token).to eq('salmon')
-        end
+          it 'returns AccessToken with #token' do
+            expect(@access.token).to eq('salmon')
+          end
 
-        it 'returns AccessToken with #refresh_token' do
-          expect(@access.refresh_token).to eq('trout')
-        end
+          it 'returns AccessToken with #refresh_token' do
+            expect(@access.refresh_token).to eq('trout')
+          end
 
-        it 'returns AccessToken with #expires_in' do
-          expect(@access.expires_in).to eq(600)
-        end
+          it 'returns AccessToken with #expires_in' do
+            expect(@access.expires_in).to eq(600)
+          end
 
-        it 'returns AccessToken with #expires_at' do
-          expect(@access.expires_at).to be_kind_of(Integer)
-        end
+          it 'returns AccessToken with #expires_at' do
+            expect(@access.expires_at).to be_kind_of(Integer)
+          end
 
-        it 'returns AccessToken with params accessible via []' do
-          expect(@access['extra_param']).to eq('steve')
+          it 'returns AccessToken with params accessible via []' do
+            expect(@access['extra_param']).to eq('steve')
+          end
         end
       end
     end

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -75,13 +75,14 @@ describe OAuth2::Strategy::AuthCode do
   end
 
   %w(json formencoded from_facebook).each do |mode|
-    %w(default basic_auth request_body).each do |auth_scheme|
+    [:basic_auth, :request_body].each do |auth_scheme|
       [:get, :post].each do |verb|
         describe "#get_token (#{mode}, access_token_method=#{verb}, auth_scheme=#{auth_scheme})" do
           before do
             @mode = mode
             client.options[:token_method] = verb
-            @access = subject.get_token(code, {}, auth_scheme == 'default' ? {} : {'auth_scheme' => auth_scheme})
+            client.options[:auth_scheme] = auth_scheme
+            @access = subject.get_token(code, {})
           end
 
           it 'returns AccessToken with same Client' do

--- a/spec/oauth2/strategy/base_spec.rb
+++ b/spec/oauth2/strategy/base_spec.rb
@@ -16,16 +16,16 @@ describe OAuth2::Strategy::Base do
       expect(subject.client_params).to eq(basic_auth)
     end
 
-    context "with auth_scheme=basic_auth" do
-      let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', auth_scheme: :basic_auth) }
+    context 'with auth_scheme=basic_auth' do
+      let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', :auth_scheme => :basic_auth) }
 
       it 'generates header values' do
         expect(subject.client_params).to eq(basic_auth)
       end
     end
 
-    context "with auth_scheme=request_body" do
-      let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', auth_scheme: :request_body) }
+    context 'with auth_scheme=request_body' do
+      let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', :auth_scheme => :request_body) }
 
       it 'generates body values' do
         expect(subject.client_params).to eq(request_body)

--- a/spec/oauth2/strategy/base_spec.rb
+++ b/spec/oauth2/strategy/base_spec.rb
@@ -1,7 +1,46 @@
 require 'helper'
 
 describe OAuth2::Strategy::Base do
+  let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com') }
+  subject { client.client_credentials }
+
   it 'initializes with a Client' do
     expect { OAuth2::Strategy::Base.new(OAuth2::Client.new('abc', 'def')) }.not_to raise_error
+  end
+
+  describe '#client_params' do
+    let(:basic_auth) { {:headers => {'Authorization' => subject.authorization(client.id, client.secret)}} }
+    let(:request_body) { {'client_id' => client.id, 'client_secret' => client.secret} }
+
+    it 'generates header values with no explicit auth scheme' do
+      expect(subject.client_params).to eq(basic_auth)
+    end
+
+    context "with auth_scheme=basic_auth" do
+      let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', auth_scheme: :basic_auth) }
+
+      it 'generates header values' do
+        expect(subject.client_params).to eq(basic_auth)
+      end
+    end
+
+    context "with auth_scheme=request_body" do
+      let(:client) { OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', auth_scheme: :request_body) }
+
+      it 'generates body values' do
+        expect(subject.client_params).to eq(request_body)
+      end
+    end
+  end
+
+  describe '#authorization' do
+    it 'generates an Authorization header value for HTTP Basic Authentication' do
+      [
+        ['abc', 'def', 'Basic YWJjOmRlZg=='],
+        ['xxx', 'secret', 'Basic eHh4OnNlY3JldA=='],
+      ].each do |client_id, client_secret, expected|
+        expect(subject.authorization(client_id, client_secret)).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/oauth2/strategy/client_credentials_spec.rb
+++ b/spec/oauth2/strategy/client_credentials_spec.rb
@@ -49,11 +49,12 @@ describe OAuth2::Strategy::ClientCredentials do
   end
 
   %w(json formencoded).each do |mode|
-    %w(default basic_auth request_body).each do |auth_scheme|
+    [:basic_auth, :request_body].each do |auth_scheme|
       describe "#get_token (#{mode}) (#{auth_scheme})" do
         before do
           @mode = mode
-          @access = subject.get_token({}, auth_scheme == 'default' ? {} : {'auth_scheme' => auth_scheme})
+          client.options[:auth_scheme] = auth_scheme
+          @access = subject.get_token
         end
 
         it 'returns AccessToken with same Client' do

--- a/spec/oauth2/strategy/client_credentials_spec.rb
+++ b/spec/oauth2/strategy/client_credentials_spec.rb
@@ -37,17 +37,6 @@ describe OAuth2::Strategy::ClientCredentials do
     end
   end
 
-  describe '#authorization' do
-    it 'generates an Authorization header value for HTTP Basic Authentication' do
-      [
-        ['abc', 'def', 'Basic YWJjOmRlZg=='],
-        ['xxx', 'secret', 'Basic eHh4OnNlY3JldA=='],
-      ].each do |client_id, client_secret, expected|
-        expect(subject.authorization(client_id, client_secret)).to eq(expected)
-      end
-    end
-  end
-
   %w(json formencoded).each do |mode|
     [:basic_auth, :request_body].each do |auth_scheme|
       describe "#get_token (#{mode}) (#{auth_scheme})" do


### PR DESCRIPTION
http://tools.ietf.org/html/rfc6749#section-2.3.1

> Including the client credentials in the request-body using the two
>    parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
>    to directly utilize the HTTP Basic authentication scheme (or other
>    password-based HTTP authentication schemes).  The parameters can only
>    be transmitted in the request-body and MUST NOT be included in the
>    request URI.
