### PR TITLE
Create expires_in method for access tokens

### DIFF
--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -132,7 +132,16 @@ describe AccessToken do
       allow(Time).to receive(:now).and_return(@now)
       expect(access).to be_expired
     end
+  end
 
+  describe '#expires_in' do
+    before { allow(Time).to receive(:now).and_return(Time.parse('Jan 1 2000')) }
+
+    it 'returns the seconds left until the token expires' do
+      @then = Time.now.to_i + 1800
+      access = AccessToken.new(client, token, :refresh_token => 'abaca', :expires_at => @then)
+      expect(access.expires_in).to eq(1800)
+    end
   end
 
   describe '#refresh!' do

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -88,10 +88,12 @@ describe MACToken do
   end
 
   describe '.from_access_token' do
+    let(:one_second_later) { Time.now.to_i + 1}
+
     let(:access_token) do
       AccessToken.new(
         client, token,
-        :expires_at => 1,
+        :expires_at => one_second_later,
         :expires_in => 1,
         :refresh_token => 'abc',
         :random => 1
@@ -107,7 +109,7 @@ describe MACToken do
     end
 
     it 'initializes configuration options' do
-      expect(subject.expires_at).to eq(1)
+      expect(subject.expires_at).to eq(one_second_later)
       expect(subject.expires_in).to eq(1)
       expect(subject.refresh_token).to eq('abc')
     end


### PR DESCRIPTION
This method ensures that that calling `#expires_in` on an `OAuth2::AccessToken` instance will always return the current number of seconds remaining until the token expires.