### PR TITLE
Loosen rack requirement to allow testing with rack master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *~
 .bundle
 .rvmrc
-Gemfile.lock
+Gemfile*.lock
 coverage/*
 log/*
 measurement/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,21 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby-18mode
   - jruby-19mode
   - jruby-head
   - rbx-2
   - ruby-head
+gemfile:
+  - Gemfile
 matrix:
+  include:
+    - rvm: 2.2
+      gemfile: Gemfile.rack-master
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+    - gemfile: Gemfile.rack-master
   fast_finish: true
 sudo: false

--- a/Gemfile.rack-master
+++ b/Gemfile.rack-master
@@ -1,0 +1,24 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rdoc'
+
+gem 'rack', github: 'rack/rack'
+
+group :development do
+  gem 'pry'
+end
+
+group :test do
+  gem 'addressable'
+  gem 'backports'
+  gem 'coveralls'
+  gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
+  gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
+  gem 'rspec', '>= 3'
+  gem 'rubocop', '>= 0.25', :platforms => [:ruby_19, :ruby_20, :ruby_21]
+  gem 'simplecov', '>= 0.9'
+  gem 'yardstick'
+end
+
+gemspec

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -36,7 +36,7 @@ module OAuth2
     # @option opts [String] :header_format ('Bearer %s') the string format to use for the Authorization header
     # @option opts [String] :param_name ('access_token') the parameter name to use for transmission of the
     #    Access Token value in :body or :query transmission mode
-    def initialize(client, token, opts = {})
+    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize
       @client = client
       @token = token.to_s
       [:refresh_token, :expires_in, :expires_at].each do |arg|
@@ -63,7 +63,7 @@ module OAuth2
     #
     # @return [Boolean]
     def expires?
-      !!@expires_at # rubocop:disable DoubleNegation
+      !!@expires_at
     end
 
     # Whether or not the token is expired
@@ -149,7 +149,7 @@ module OAuth2
 
   private
 
-    def token=(opts) # rubocop:disable MethodLength
+    def token=(opts) # rubocop:disable MethodLength, Metrics/AbcSize
       case options[:mode]
       when :header
         opts[:headers] ||= {}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -85,7 +85,7 @@ module OAuth2
     #   code response for this request.  Will default to client option
     # @option opts [Symbol] :parse @see Response::initialize
     # @yield [req] The Faraday request
-    def request(verb, url, opts = {}) # rubocop:disable CyclomaticComplexity, MethodLength
+    def request(verb, url, opts = {}) # rubocop:disable CyclomaticComplexity, MethodLength, Metrics/AbcSize
       connection.response :logger, ::Logger.new($stdout) if ENV['OAUTH_DEBUG'] == 'true'
 
       url = connection.build_url(url, opts[:params]).to_s
@@ -125,12 +125,12 @@ module OAuth2
     # @param [Hash] access token options, to pass to the AccessToken object
     # @param [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initalized AccessToken
-    def get_token(params, access_token_opts = {}, access_token_class = AccessToken)
+    def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}
       if options[:token_method] == :post
         headers = params.delete(:headers)
         opts[:body] = params
-        opts[:headers] =  {'Content-Type' => 'application/x-www-form-urlencoded'}
+        opts[:headers] = {'Content-Type' => 'application/x-www-form-urlencoded'}
         opts[:headers].merge!(headers) if headers
       else
         opts[:params] = params

--- a/lib/oauth2/mac_token.rb
+++ b/lib/oauth2/mac_token.rb
@@ -116,7 +116,7 @@ module OAuth2
 
     # Base64.strict_encode64 is not available on Ruby 1.8.7
     def strict_encode64(str)
-      Base64.encode64(str).gsub("\n", '')
+      Base64.encode64(str).delete("\n")
     end
   end
 end

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -29,7 +29,7 @@ module OAuth2
       # @param [String] The client ID
       # @param [String] the client secret
       def authorization(client_id, client_secret)
-        'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub("\n", '')
+        'Basic ' + Base64.encode64(client_id + ':' + client_secret).delete("\n")
       end
     end
   end

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'
-  spec.add_dependency 'rack', '~> 1.2'
+  spec.add_dependency 'rack', ['>= 1.2', '< 2.0']
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -31,7 +31,7 @@ describe AccessToken do
       expect(target.params['foo']).to eq('bar')
     end
 
-    def assert_initialized_token(target)
+    def assert_initialized_token(target) # rubocop:disable Metrics/AbcSize
       expect(target.token).to eq(token)
       expect(target).to be_expires
       expect(target.params.keys).to include('foo')
@@ -132,7 +132,6 @@ describe AccessToken do
       allow(Time).to receive(:now).and_return(@now)
       expect(access).to be_expired
     end
-
   end
 
   describe '#refresh!' do

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -52,5 +52,4 @@ describe OAuth2::Strategy::Assertion do
       end
     end
   end
-
 end

--- a/spec/oauth2/strategy/password_spec.rb
+++ b/spec/oauth2/strategy/password_spec.rb
@@ -53,5 +53,4 @@ describe OAuth2::Strategy::Password do
       end
     end
   end
-
 end


### PR DESCRIPTION
This loosens the rack version requirement to allow testing with the rack master branch as currently being required by rails 5. It also adds to travis as an allowable failure, and fixes/ignores some rubocop warnings