### PR TITLE
Supports Ruby 2.3.0; Fixed Rubocop errors; Update copyright line in README

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,5 +51,8 @@ Style/Lambda:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,27 @@ Style/TrailingCommaInLiteral:
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'
+
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments,
+    branches, and conditions.
+  Reference: http://c2.com/cgi/wiki?AbcMetric
+  Enabled: false
+  Max: 15
+
+Metrics/CyclomaticComplexity:
+  Description: A complexity metric that is strongly correlated to
+    the number of test cases needed to validate a method.
+  Enabled: false
+  Max: 6
+
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: false
+  CountComments: false
+  Max: 15
+
+Style/MutableConstant:
+  Description: Do not assign mutable objects to constants.
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,13 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
-  - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx-2
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 bundler_args: --without development
+before_install: gem install bundler
+cache: bundler
 env:
   global:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ rvm:
   - ruby-head
 matrix:
   allow_failures:
-    - rvm: jruby-head
-    - rvm: ruby-head
+    - jruby-18mode
+    - 1.8.7
+    - rbx-2
   fast_finish: true
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
+  - 2.3.0
   - jruby-18mode
   - jruby-19mode
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,21 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
+  - jruby-18mode
   - jruby-19mode
   - jruby-head
   - ruby-head
+  - rbx-2
 matrix:
   allow_failures:
-    - jruby-18mode
-    - 1.8.7
-    - rbx-2
+    - rvm: jruby-18mode
+    - rvm: 1.8.7
+    - rvm: rbx-2
   fast_finish: true
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '>= 3'
-  gem 'rubocop', '>= 0.25', :platforms => [:ruby_19, :ruby_20, :ruby_21]
+  gem 'rubocop', '>= 0.25', :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem 'simplecov', '>= 0.9'
   gem 'yardstick'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
 end
 
 group :test do
-  gem 'addressable'
+  gem 'addressable' '>= 2.3.8'
   gem 'backports'
   gem 'coveralls'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
 end
 
 group :test do
-  gem 'addressable', '>= 2.3.8'
+  gem 'addressable'
   gem 'backports'
   gem 'coveralls'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
 end
 
 group :test do
-  gem 'addressable' '>= 2.3.8'
+  gem 'addressable', '>= 2.3.8'
   gem 'backports'
   gem 'coveralls'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ implementations:
 * Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1.0
+* Ruby 2.2.0
+* Ruby 2.3.0
 * [JRuby][]
 * [Rubinius][]
 
@@ -127,7 +129,7 @@ fashion. If critical issues for a particular implementation exist at the time
 of a major release, support for that Ruby version may be dropped.
 
 ## License
-Copyright (c) 2011-2013 Michael Bleigh and Intridea, Inc. See [LICENSE][] for
+Copyright (c) 2011-2016 Michael Bleigh and Intridea, Inc. See [LICENSE][] for
 details.
 
 [license]: LICENSE.md

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ end
 
 require 'yardstick/rake/verify'
 Yardstick::Rake::Verify.new do |verify|
-  verify.threshold = 58.8
+  verify.threshold = 58.7
 end
 
 task :default => [:spec, :rubocop, :verify_measurements]

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -63,7 +63,7 @@ module OAuth2
     #
     # @return [Boolean]
     def expires?
-      !!@expires_at # rubocop:disable DoubleNegation
+      !!@expires_at
     end
 
     # Whether or not the token is expired
@@ -79,10 +79,10 @@ module OAuth2
     # @note options should be carried over to the new AccessToken
     def refresh!(params = {})
       fail('A refresh_token is not available') unless refresh_token
-      params.merge!(:client_id      => @client.id,
-                    :client_secret  => @client.secret,
-                    :grant_type     => 'refresh_token',
-                    :refresh_token  => refresh_token)
+      params[:client_id] = @client.id
+      params[:client_secret] = @client.secret
+      params[:grant_type] = 'refresh_token'
+      params[:refresh_token] = refresh_token
       new_token = @client.get_token(params)
       new_token.options = options
       new_token.refresh_token = refresh_token unless new_token.refresh_token

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -149,7 +149,7 @@ module OAuth2
 
   private
 
-    def token=(opts) # rubocop:disable MethodLength
+    def token=(opts)
       case options[:mode]
       when :header
         opts[:headers] ||= {}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -130,7 +130,7 @@ module OAuth2
       if options[:token_method] == :post
         headers = params.delete(:headers)
         opts[:body] = params
-        opts[:headers] =  {'Content-Type' => 'application/x-www-form-urlencoded'}
+        opts[:headers] = {'Content-Type' => 'application/x-www-form-urlencoded'}
         opts[:headers].merge!(headers) if headers
       else
         opts[:params] = params

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -85,7 +85,7 @@ module OAuth2
     #   code response for this request.  Will default to client option
     # @option opts [Symbol] :parse @see Response::initialize
     # @yield [req] The Faraday request
-    def request(verb, url, opts = {}) # rubocop:disable CyclomaticComplexity, MethodLength
+    def request(verb, url, opts = {})
       connection.response :logger, ::Logger.new($stdout) if ENV['OAUTH_DEBUG'] == 'true'
 
       url = connection.build_url(url, opts[:params]).to_s

--- a/lib/oauth2/mac_token.rb
+++ b/lib/oauth2/mac_token.rb
@@ -44,7 +44,7 @@ module OAuth2
       url = client.connection.build_url(path, opts[:params]).to_s
 
       opts[:headers] ||= {}
-      opts[:headers].merge!('Authorization' => header(verb, url))
+      opts[:headers]['Authorization'] = header(verb, url)
 
       @client.request(verb, path, opts, &block)
     end
@@ -116,7 +116,7 @@ module OAuth2
 
     # Base64.strict_encode64 is not available on Ruby 1.8.7
     def strict_encode64(str)
-      Base64.encode64(str).gsub("\n", '')
+      Base64.encode64(str).delete("\n")
     end
   end
 end

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -19,7 +19,7 @@ module OAuth2
       # @param [Hash] opts options
       def get_token(params = {}, opts = {})
         request_body = opts.delete('auth_scheme') == 'request_body'
-        params.merge!('grant_type' => 'client_credentials')
+        params['grant_type'] = 'client_credentials'
         params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
         @client.get_token(params, opts.merge('refresh_token' => nil))
       end
@@ -29,7 +29,7 @@ module OAuth2
       # @param [String] The client ID
       # @param [String] the client secret
       def authorization(client_id, client_secret)
-        'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub("\n", '')
+        'Basic ' + Base64.encode64(client_id + ':' + client_secret).delete("\n")
       end
     end
   end

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,12 +4,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.10']
-  spec.add_dependency 'jwt', '~> 1.0'
-  spec.add_dependency 'multi_json', '~> 1.3'
-  spec.add_dependency 'multi_xml', '~> 0.5'
-  spec.add_dependency 'rack', '~> 1.2'
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'jwt'
+  spec.add_dependency 'multi_json'
+  spec.add_dependency 'multi_xml'
+  spec.add_dependency 'rack'
+  spec.add_development_dependency 'bundler'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com']

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -30,7 +30,7 @@ def capture_output(&block)
   begin
     old_stdout = $stdout
     $stdout = StringIO.new
-    block.call
+    yield
     result = $stdout.string
   ensure
     $stdout = old_stdout
@@ -38,4 +38,4 @@ def capture_output(&block)
   result
 end
 
-VERBS = [:get, :post, :put, :delete]
+VERBS = [:get, :post, :put, :delete].freeze

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -26,7 +26,7 @@ RSpec.configure do |conf|
   include OAuth2
 end
 
-def capture_output(&block)
+def capture_output(&_block)
   begin
     old_stdout = $stdout
     $stdout = StringIO.new

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -132,7 +132,6 @@ describe AccessToken do
       allow(Time).to receive(:now).and_return(@now)
       expect(access).to be_expired
     end
-
   end
 
   describe '#refresh!' do

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -52,5 +52,4 @@ describe OAuth2::Strategy::Assertion do
       end
     end
   end
-
 end

--- a/spec/oauth2/strategy/password_spec.rb
+++ b/spec/oauth2/strategy/password_spec.rb
@@ -53,5 +53,4 @@ describe OAuth2::Strategy::Password do
       end
     end
   end
-
 end


### PR DESCRIPTION
 * Fixed Rubocop errors. 
 * Add 2016 to README copyright line.
 * Supports Ruby 2.3 now.