### PR TITLE
Test support for rack 2.0 on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .rvmrc
 Gemfile.lock
+Gemfile.rack2.lock
 coverage/*
 log/*
 measurement/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ rvm:
   - rbx-2
   - ruby-head
 matrix:
+  include:
+    - rvm: 2.2.4
+      gemfile: Gemfile.rack2
+    - rvm: 2.3.0
+      gemfile: Gemfile.rack2
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 3. Add specs for your unimplemented feature or bug fix.
 4. Run `bundle exec rake spec`. If your specs pass, return to step 3.
 5. Implement your feature or bug fix.
-6. Run `bundle exec rake`. If your specs fail, return to step 5.
+6. Run `bundle exec rake`. If your specs fail, return to step 5. To verify against both rack 1.0 and 2.0, use `bundle exec rake wwtd:local`.
 7. Run `open coverage/index.html`. If your changes are not completely covered
    by your tests, return to step 3.
 8. Add documentation for your feature or bug fix.

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gem 'rake'
 gem 'rdoc'
 
+gem 'jwt', '< 1.5.2', :platforms => [:jruby_18, :ruby_18]
+
 group :development do
   gem 'pry'
 end

--- a/Gemfile.rack2
+++ b/Gemfile.rack2
@@ -1,0 +1,23 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rdoc'
+
+group :development do
+  gem 'pry'
+end
+
+group :test do
+  gem 'addressable'
+  gem 'backports'
+  gem 'coveralls'
+  gem 'mime-types'
+  gem 'rack', '~> 2.0.0.alpha'
+  gem 'rest-client'
+  gem 'rspec', '>= 3'
+  gem 'rubocop', '>= 0.36'
+  gem 'simplecov', '>= 0.9'
+  gem 'yardstick'
+end
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,12 @@ Bundler::GemHelper.install_tasks
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
+begin
+  require 'wwtd/tasks'
+rescue LoadError => _e
+  nil # It's OK, wwtd isn't installed
+end
+
 task :test => :spec
 
 namespace :doc do

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -5,7 +5,7 @@ require 'oauth2/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', ['>= 0.8', '< 0.10']
-  spec.add_dependency 'jwt', '~> 1.0', '< 1.5.2'
+  spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', ['>= 1.2', '< 3']

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', ['>= 1.2', '< 3']
   spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'wwtd'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com']


### PR DESCRIPTION
@sferik 

Hi!

This gem is on our path to get our gems compatible with Rails 5.0.0.beta1. I noticed that you unlocked the hard dependency on `rack` but it wasn't exactly tested yet. This should do.

I also unlocked the dependency on jwt since it's only for ruby 1.8.

Would you mind releasing a new version, at least alpha/beta, so we can bundle with rails 5 and this gem?