### PR TITLE
dup the options hash to avoid accidental mutation

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -10,6 +10,7 @@ module OAuth2
       # @param [Hash] a hash of AccessToken property values
       # @return [AccessToken] the initalized AccessToken
       def from_hash(client, hash)
+        hash = hash.dup
         new(client, hash.delete('access_token') || hash.delete(:access_token), hash)
       end
 
@@ -39,6 +40,7 @@ module OAuth2
     def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize
       @client = client
       @token = token.to_s
+      opts = opts.dup
       [:refresh_token, :expires_in, :expires_at].each do |arg|
         instance_variable_set("@#{arg}", opts.delete(arg) || opts.delete(arg.to_s))
       end

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -44,6 +44,13 @@ describe AccessToken do
       assert_initialized_token(target)
     end
 
+    it 'does not modify opts hash' do
+      hash = {:access_token => token, :expires_at => Time.now.to_i}
+      hash_before = hash.dup
+      AccessToken.from_hash(client, hash)
+      expect(hash).to eq(hash_before)
+    end
+
     it 'initalizes with a form-urlencoded key/value string' do
       kvform = "access_token=#{token}&expires_at=#{Time.now.to_i + 200}&foo=bar"
       target = AccessToken.from_kvform(client, kvform)
@@ -55,6 +62,13 @@ describe AccessToken do
       expect(target.options[:param_name]).to eq('foo')
       expect(target.options[:header_format]).to eq('Bearer %')
       expect(target.options[:mode]).to eq(:body)
+    end
+
+    it 'does not modify opts hash' do
+      opts = {:param_name => 'foo', :header_format => 'Bearer %', :mode => :body}
+      opts_before = opts.dup
+      AccessToken.new(client, token, opts)
+      expect(opts).to eq(opts_before)
     end
 
     it 'initializes with a string expires_at' do


### PR DESCRIPTION
Fixes #215 

Hi!

I just had an annoying bug with accidental mutation of a hash.

```ruby
class Client
  def initialize(token, opts = {})
    @token = token
    @opts = opts
  end

  def access_token
    OAuth2::AccessToken.new(client, @token, @opts)
  end
   
  def client
    # ...
  end
end

client = Client.new("123123123", refresh_token: "refresh-token-123", expires_at: "123123123")

client.access_token.refresh_token #=> "refresh-token-123"

# Run it again
client.access_token.refresh_token #=> nil
```

Why does this happen?
Here: https://github.com/intridea/oauth2/blob/master/lib/oauth2/access_token.rb#L43
We run `opts.delete(...)` which changes the opts hash in-place.

Instead, we should `dup` the hash to avoid this issue.

Any input?