### PR TITLE
Keep handlers when specifying connection_build.

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -52,7 +52,7 @@ module OAuth2
     def connection
       @connection ||= begin
         conn = Faraday.new(site, options[:connection_opts])
-        conn.build do |b|
+        conn.build(keep: true) do |b|
           options[:connection_build].call(b)
         end if options[:connection_build]
         conn


### PR DESCRIPTION
It is very confusing that specifying an empty connection_build block changes the behaviour of the requests. So in order to allow easy use of connection_build, keep all handlers that were already specified.