### PR TITLE
Restrict rake to < 11.0 for compatibility with ruby18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jwt', '< 1.5.2', :platforms => [:jruby_18, :ruby_18]
-gem 'rake'
+gem 'rake', '< 11.0'
 gem 'rdoc'
 
 group :development do


### PR DESCRIPTION
Example of the issue: https://travis-ci.org/intridea/oauth2/jobs/122118341