### PR TITLE
Add support to ClientCredentials to support authorization formats other than just HTTP Basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ token = OAuth2::AccessToken.from_kvform(client, query_string)
 
 token = client.password.get_token('username', 'password')
 
-token = client.client_credentials.get_token
+# :header_format - the string format to use for the Authorization header
+token = client.client_credentials.get_token({'client_id' => client_id, 'client_secret' => client_secret}, {:header_format' => 'Basic'})
 
 token = client.assertion.get_token(assertion_params)
 ```

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ token = OAuth2::AccessToken.from_kvform(client, query_string)
 
 token = client.password.get_token('username', 'password')
 
-# :header_format - the string format to use for the Authorization header
-token = client.client_credentials.get_token({'client_id' => client_id, 'client_secret' => client_secret}, {:header_format' => 'Basic'})
+token = client.client_credentials.get_token
 
 token = client.assertion.get_token(assertion_params)
 ```

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -17,19 +17,21 @@ module OAuth2
       #
       # @param [Hash] params additional params
       # @param [Hash] opts options
+      # @option opts [String] :header_format ('Basic') the string format to use for the Authorization header
       def get_token(params = {}, opts = {})
         request_body = opts.delete('auth_scheme') == 'request_body'
         params['grant_type'] = 'client_credentials'
-        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
+        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'], opts.delete(:header_format) || 'Basic')}})
         @client.get_token(params, opts.merge('refresh_token' => nil))
       end
 
-      # Returns the Authorization header value for Basic Authentication
+      # Returns the Authorization header value for Authentication
       #
       # @param [String] The client ID
       # @param [String] the client secret
-      def authorization(client_id, client_secret)
-        'Basic ' + Base64.encode64(client_id + ':' + client_secret).delete("\n")
+      # @param [String] the authorization header string format
+      def authorization(client_id, client_secret, header_format)
+        header_format + ' ' + Base64.encode64(client_id + ':' + client_secret).delete("\n")
       end
     end
   end

--- a/spec/oauth2/strategy/client_credentials_spec.rb
+++ b/spec/oauth2/strategy/client_credentials_spec.rb
@@ -43,7 +43,18 @@ describe OAuth2::Strategy::ClientCredentials do
         ['abc', 'def', 'Basic YWJjOmRlZg=='],
         ['xxx', 'secret', 'Basic eHh4OnNlY3JldA=='],
       ].each do |client_id, client_secret, expected|
-        expect(subject.authorization(client_id, client_secret)).to eq(expected)
+        expect(subject.authorization(client_id, client_secret, 'Basic')).to eq(expected)
+      end
+    end
+  end
+
+  describe '#authorization bearer' do
+    it 'generates an Authorization header value for Bearer Authentication' do
+      [
+        ['abc', 'def', 'Bearer YWJjOmRlZg=='],
+        ['xxx', 'secret', 'Bearer eHh4OnNlY3JldA=='],
+      ].each do |client_id, client_secret, expected|
+        expect(subject.authorization(client_id, client_secret, 'Bearer')).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
Adds support to ClientCredentials get_token and authorization methods to support authorization formats other than just HTTP Basic Authentication, such as, Bearer Authentication. Defaults to 'Basic' if header_format is not defined in opts hash of get_token method.

``` ruby
# Basic auth works the exact same as before
@new_token = @client.client_credentials.get_token({
  'client_id' => client_id,
  'client_secret' => client_secret})

# Bearer auth, pass in hash as third param with :header_format defined
@new_token = @client.client_credentials.get_token({
  'client_id' => client_id,
  'client_secret' => client_secret},
  {:header_format' => 'Bearer'})
```
