### PR TITLE
Remove dependency on encoding class

### DIFF
--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -1,3 +1,5 @@
+require 'kconv'
+
 module OAuth2
   class Error < StandardError
     attr_reader :response, :code, :description
@@ -16,7 +18,15 @@ module OAuth2
         message << "#{@code}: #{@description}"
       end
 
-      message << response.body.force_encoding(__ENCODING__)
+      if message[0] && message[0].respond_to?(:encoding)
+        script_encoding = message[0].encoding
+        response_body_encoding = response.body.encoding
+        response_body = response.body.kconv(script_encoding, response_body_encoding)
+      else
+        response_body = response.body
+      end
+
+      message << response_body
 
       super(message.join("\n"))
     end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -1,4 +1,6 @@
+# coding: utf-8
 require 'helper'
+require 'kconv'
 
 describe OAuth2::Client do
   let!(:error_value) { 'invalid_token' }
@@ -16,7 +18,7 @@ describe OAuth2::Client do
         stub.post('/redirect')        { |env| [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
         stub.get('/error')            { |env| [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
         stub.get('/empty_get')        { |env| [204, {}, nil] }
-        stub.get('/invalid_encoding') { |env| [500, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => "\xE2\x88\x9E").force_encoding('ASCII-8BIT')] }
+        stub.get('/different_encoding') { |env| [500, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => "∞").kconv(Kconv::EUC, Kconv::UTF8)] }
       end
     end
   end
@@ -165,7 +167,7 @@ describe OAuth2::Client do
       expect(response.error).not_to be_nil
     end
 
-    %w(/unauthorized /conflict /error /invalid_encoding).each do |error_path|
+    %w(/unauthorized /conflict /error /different_encoding).each do |error_path|
       it "raises OAuth2::Error on error response to path #{error_path}" do
         expect { subject.request(:get, error_path) }.to raise_error(OAuth2::Error)
       end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -9,15 +9,15 @@ describe OAuth2::Client do
   subject do
     OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
       builder.adapter :test do |stub|
-        stub.get('/success')          { |env| [200, {'Content-Type' => 'text/awesome'}, 'yay'] }
-        stub.get('/reflect')          { |env| [200, {}, env[:body]] }
-        stub.post('/reflect')         { |env| [200, {}, env[:body]] }
-        stub.get('/unauthorized')     { |env| [401, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => error_description_value)] }
-        stub.get('/conflict')         { |env| [409, {'Content-Type' => 'text/plain'}, 'not authorized'] }
-        stub.get('/redirect')         { |env| [302, {'Content-Type' => 'text/plain', 'location' => '/success'}, ''] }
-        stub.post('/redirect')        { |env| [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
-        stub.get('/error')            { |env| [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
-        stub.get('/empty_get')        { |env| [204, {}, nil] }
+        stub.get('/success')            { |env| [200, {'Content-Type' => 'text/awesome'}, 'yay'] }
+        stub.get('/reflect')            { |env| [200, {}, env[:body]] }
+        stub.post('/reflect')           { |env| [200, {}, env[:body]] }
+        stub.get('/unauthorized')       { |env| [401, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => error_description_value)] }
+        stub.get('/conflict')           { |env| [409, {'Content-Type' => 'text/plain'}, 'not authorized'] }
+        stub.get('/redirect')           { |env| [302, {'Content-Type' => 'text/plain', 'location' => '/success'}, ''] }
+        stub.post('/redirect')          { |env| [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
+        stub.get('/error')              { |env| [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
+        stub.get('/empty_get')          { |env| [204, {}, nil] }
         stub.get('/different_encoding') { |env| [500, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => "∞").kconv(Kconv::EUC, Kconv::UTF8)] }
       end
     end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 require 'helper'
-require 'kconv'
+require 'nkf'
 
 describe OAuth2::Client do
   let!(:error_value) { 'invalid_token' }
@@ -18,7 +18,7 @@ describe OAuth2::Client do
         stub.post('/redirect')          { |env| [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
         stub.get('/error')              { |env| [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
         stub.get('/empty_get')          { |env| [204, {}, nil] }
-        stub.get('/different_encoding') { |env| [500, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => "∞").kconv(Kconv::EUC, Kconv::UTF8)] }
+        stub.get('/different_encoding') { |env| [500, {'Content-Type' => 'application/json'}, NKF.nkf('-We', MultiJson.encode(:error => error_value, :error_description => "∞"))] }
       end
     end
   end


### PR DESCRIPTION
fix broken build about #251

Encoding class are implemented as of ruby 1.9.

In ruby 1.8, string don't have the encoding information.
So no error is raised by joining different encoding strings.
```
irb(main):001:0> ["∞".kconv(Kconv::EUC, Kconv::UTF8), "∞"].join
=> "\241\347\342\210\236"
```

As of 1.9
```
irb(main):001:0> ["∞".kconv(Kconv::EUC, Kconv::UTF8), "∞"].join
Encoding::CompatibilityError: incompatible character encodings: EUC-JP and UTF-8
```

