### PR TITLE
Limit json version to 1.8.x for Ruby1.8.x and 1.9.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem 'rubocop', '>= 0.37', :platforms => [:ruby_19, :ruby_20, :ruby_21]
   gem 'simplecov', '>= 0.9'
   gem 'yardstick'
+  gem 'json', '~> 1.8', :platforms => [:ruby_18, :ruby_19]
 end
 
 gemspec


### PR DESCRIPTION
Latest `json` gem no longer supports Ruby 1.8.x and 1.9.x .
