### PR TITLE
Fix error encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - ruby-head
 matrix:
   allow_failures:
+    - rvm: 1.8.7
     - rvm: jruby-head
     - rvm: ruby-head
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,15 @@ group :test do
   gem 'rack', '~> 1.2', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18, :ruby_18]
   gem 'rspec', '>= 3'
-  gem 'rubocop', '>= 0.37', :platforms => [:ruby_19, :ruby_20, :ruby_21]
+  gem 'rubocop', '>= 0.37', :platforms => [:ruby_20, :ruby_21]
   gem 'simplecov', '>= 0.9'
   gem 'yardstick'
+
+  platforms :ruby_18, :ruby_19 do
+    gem 'json', '< 2.0'
+    gem 'tins', '< 1.7'
+    gem 'term-ansicolor', '< 1.4.0'
+  end
 end
 
 gemspec

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -136,8 +136,10 @@ module OAuth2
         opts[:params] = params
       end
       response = request(options[:token_method], token_url, opts)
-      error = Error.new(response)
-      raise(error) if options[:raise_errors] && !(response.parsed.is_a?(Hash) && response.parsed['access_token'])
+      if options[:raise_errors] && !(response.parsed.is_a?(Hash) && response.parsed['access_token'])
+        error = Error.new(response)
+        raise(error)
+      end
       access_token_class.from_hash(self, response.parsed.merge(access_token_opts))
     end
 

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -27,7 +27,7 @@ module OAuth2
 
       error_message = if opts[:error_description] && opts[:error_description].respond_to?(:encoding)
                         script_encoding = opts[:error_description].encoding
-                        response_body.encode(script_encoding)
+                        response_body.encode(script_encoding, :invalid => :replace, :undef => :replace)
                       else
                         response_body
                       end

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'helper'
 
 describe OAuth2::Strategy::AuthCode do
@@ -47,6 +49,25 @@ describe OAuth2::Strategy::AuthCode do
     it 'includes passed in options' do
       cb = 'http://myserver.local/oauth/callback'
       expect(subject.authorize_url(:redirect_uri => cb)).to include("redirect_uri=#{Rack::Utils.escape(cb)}")
+    end
+  end
+
+  describe '#get_token (handling utf-8 data)' do
+    let(:json_token) { MultiJson.encode(:expires_in => 600, :access_token => 'salmon', :refresh_token => 'trout', :extra_param => 'André') }
+
+    before do
+      @mode = 'json'
+      client.options[:token_method] = :post
+    end
+
+    it 'should not raise an error' do
+      expect { subject.get_token(code) }.to_not raise_error
+    end
+
+    it 'should not create an error instance' do
+      expect(OAuth2::Error).to_not receive(:new)
+
+      subject.get_token(code)
     end
   end
 


### PR DESCRIPTION
Fix for #270 

This makes two changes
- adds handling of unknown encoding bytes when re-encoding the error response
- only instantiates the Error class if an actual error has occurred.
