### PR TITLE
Loosen faraday requirements to allow 0.10 to be picked up

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.10']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 1.0']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
Used a similar upper version to what @mislav did in https://github.com/lostisland/faraday_middleware/commit/6532e65c3e25ce8bdf884d118602a41efc0d42e3#diff-2c97a3fba04553020532f4508b0b3bb4