### PR TITLE
Handle redirect_uri according to OAuth 2 spec

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -183,7 +183,7 @@ module OAuth2
       @assertion ||= OAuth2::Strategy::Assertion.new(self)
     end
 
-    # The redirect_uri parameters, if configured.
+    # The redirect_uri parameters, if configured
     #
     # The redirect_uri query parameter is OPTIONAL (though encouraged) when
     # requesting authorization. If it is provided at authorization time it MUST
@@ -192,10 +192,13 @@ module OAuth2
     # Providing the :redirect_uri to the OAuth2::Client instantiation will take
     # care of managing this.
     #
+    # @api semipublic
+    #
     # @see https://tools.ietf.org/html/rfc6749#section-4.1
     # @see https://tools.ietf.org/html/rfc6749#section-4.1.3
     # @see https://tools.ietf.org/html/rfc6749#section-4.2.1
     # @see https://tools.ietf.org/html/rfc6749#section-10.6
+    # @return [Hash] the params to add to a request or URL
     def redirection_params
       if options[:redirect_uri]
         {'redirect_uri' => options[:redirect_uri]}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -16,6 +16,7 @@ module OAuth2
     # @param [String] client_secret the client_secret value
     # @param [Hash] opts the options to create the client with
     # @option opts [String] :site the OAuth2 provider site host
+    # @option opts [String] :redirect_uri the absolute URI to the Redirection Endpoint for use in authorization grants and token exchange
     # @option opts [String] :authorize_url ('/oauth/authorize') absolute or relative URL path to the Authorization endpoint
     # @option opts [String] :token_url ('/oauth/token') absolute or relative URL path to the Token endpoint
     # @option opts [Symbol] :token_method (:post) HTTP method to use to request token (:get or :post)
@@ -66,7 +67,8 @@ module OAuth2
     # The authorize endpoint URL of the OAuth2 provider
     #
     # @param [Hash] params additional query parameters
-    def authorize_url(params = nil)
+    def authorize_url(params = {})
+      params = (params || {}).merge(redirection_params)
       connection.build_url(options[:authorize_url], params).to_s
     end
 
@@ -179,6 +181,27 @@ module OAuth2
 
     def assertion
       @assertion ||= OAuth2::Strategy::Assertion.new(self)
+    end
+
+    # The redirect_uri parameters, if configured.
+    #
+    # The redirect_uri query parameter is OPTIONAL (though encouraged) when
+    # requesting authorization. If it is provided at authorization time it MUST
+    # also be provided with the token exchange request.
+    #
+    # Providing the :redirect_uri to the OAuth2::Client instantiation will take
+    # care of managing this.
+    #
+    # @see https://tools.ietf.org/html/rfc6749#section-4.1
+    # @see https://tools.ietf.org/html/rfc6749#section-4.1.3
+    # @see https://tools.ietf.org/html/rfc6749#section-4.2.1
+    # @see https://tools.ietf.org/html/rfc6749#section-10.6
+    def redirection_params
+      if options[:redirect_uri]
+        {'redirect_uri' => options[:redirect_uri]}
+      else
+        {}
+      end
     end
   end
 end

--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -25,7 +25,8 @@ module OAuth2
       # @param [Hash] opts options
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
       def get_token(code, params = {}, opts = {})
-        params = {'grant_type' => 'authorization_code', 'code' => code}.merge(params)
+        params = {'grant_type' => 'authorization_code', 'code' => code}.merge(@client.redirection_params).merge(params)
+
         @client.get_token(params, opts)
       end
     end


### PR DESCRIPTION
Passing redirect_uri to authorization server at grant time is optional (though encouraged and very commonly enforced by providers). However, if it is passed (as it often is) it is REQUIRED to be passed when using the grant code to get an access token.

This change allows a user to optionally provide a `redirect_uri` when configuring the client to have it passed as a parameter in both the redirect to the authorization server and the later token exchange.

Relevant sections of the spec:

+ https://tools.ietf.org/html/rfc6749#section-4.1
+ https://tools.ietf.org/html/rfc6749#section-4.1.3
+ https://tools.ietf.org/html/rfc6749#section-4.2.1
+ https://tools.ietf.org/html/rfc6749#section-10.6

This change is backwards compatible, its use is optional, and it handles more of the spec so that the user does not have to.

Note: this will conflict with #280. If both are cleared for merging, I'll be happy to rebase the other for a clean merge promptly.