### PR TITLE
Rename method for clarity

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -105,7 +105,7 @@ module OAuth2
     # @param [Hash] opts the options to make the request with
     # @see Client#request
     def request(verb, path, opts = {}, &block)
-      self.token = opts
+      configure_authentication!(opts)
       @client.request(verb, path, opts, &block)
     end
 
@@ -151,7 +151,7 @@ module OAuth2
 
   private
 
-    def token=(opts) # rubocop:disable MethodLength, Metrics/AbcSize
+    def configure_authentication!(opts) # rubocop:disable MethodLength, Metrics/AbcSize
       case options[:mode]
       when :header
         opts[:headers] ||= {}


### PR DESCRIPTION
Using a setter style method call for something which only mutates its
arguments is very misleading.

It looks like this change was made blindly to adress some Rubocop
warnings (the method used to be called `#set_token`).

Hopefully this is a bit clearer.