### PR TITLE
support oauth2 v0.11.0

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.11']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
I'm having some dependency conflicts updating the gems in my app, I mainly want this because the twitter gem bumped its faraday dependency.
https://github.com/sferik/twitter/commit/6eb494d7c4ac1b06730d22bc9183e6a9035e3643

I don't see anything potentially breaking in 0.11.0 except the new `block syntax to customise the adapter`:
https://github.com/lostisland/faraday/releases/tag/v0.11.0

I'm not sure if its possible to test against faraday 0.11.0 on CI, but I tried running the tests locally with faraday 0.11.0 and I didn't see any breakage.