### PR TITLE
Relax faraday constraint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Metrics/BlockNesting:
   Max: 2
 

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.11']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 1.0']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
This commit adds support for versions 0.10.x and 0.11.x which have been released recently. It will also support 0.x until 1.0, which matches the existing pessimistic dependency version constraints and should work as long as `faraday` adheres to SemVer conventions.