### PR TITLE
Allow faraday 0.11 to be used

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.11']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
Similar to https://github.com/intridea/oauth2/pull/277
Faraday 0.11 was released and ensures compatibility with Ruby 2.4 (which I added to travis.yml as well): https://github.com/lostisland/faraday/releases/tag/v0.11.0

Fixes #290