### PR TITLE
Fix rubocop and display cop name when offense is found

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,3 +59,6 @@ Style/SpaceInsideHashLiteralBraces:
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'
+
+Metrics/BlockLength:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,9 @@ end
 
 begin
   require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
+  RuboCop::RakeTask.new do |task|
+    task.options = ['-D'] # Display the name of the failing cops
+  end
 rescue LoadError
   task :rubocop do
     $stderr.puts 'RuboCop is disabled'


### PR DESCRIPTION
@sferik 

This adds a new ignore to rubocop so the test-suite will pass with latest Rubocop.
I also added an option to the rake task so the name of the failing cop will be displayed, making it easier to understand what's going on.

I would advise locking Rubocop in the gemspec to avoid having to go through this when contributing for something different 😄 