### PR TITLE
Add ruby 2.4.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.0
   - jruby-9.0.5.0
   - jruby-head
   - ruby-head


### PR DESCRIPTION
@sferik 

It's been out since Christmas, better ensure compatibility I'd think 😄 