### PR TITLE
Fix rubocop update changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,10 @@ Style/Lambda:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+# Disable for Ruby 1.9.3 compatibility
+Style/SymbolArray:
+  Enabled: false
+
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'faraday', '~> 0.9.2', :platforms => [:jruby_18, :ruby_18]

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/lib/oauth2.rb
+++ b/lib/oauth2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'oauth2/error'
 require 'oauth2/authenticator'
 require 'oauth2/client'

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   class AccessToken
     attr_reader :client, :token, :expires_in, :expires_at, :params

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -10,7 +10,7 @@ module OAuth2
       #
       # @param [Client] the OAuth2::Client instance
       # @param [Hash] a hash of AccessToken property values
-      # @return [AccessToken] the initalized AccessToken
+      # @return [AccessToken] the initialized AccessToken
       def from_hash(client, hash)
         hash = hash.dup
         new(client, hash.delete('access_token') || hash.delete(:access_token), hash)
@@ -20,13 +20,13 @@ module OAuth2
       #
       # @param [Client] client the OAuth2::Client instance
       # @param [String] kvform the application/x-www-form-urlencoded string
-      # @return [AccessToken] the initalized AccessToken
+      # @return [AccessToken] the initialized AccessToken
       def from_kvform(client, kvform)
         from_hash(client, Rack::Utils.parse_query(kvform))
       end
     end
 
-    # Initalize an AccessToken
+    # Initialize an AccessToken
     #
     # @param [Client] client the OAuth2::Client instance
     # @param [String] token the Access Token value

--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 
 module OAuth2

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -132,7 +132,7 @@ module OAuth2
     # @param [Hash] params a Hash of params for the token endpoint
     # @param [Hash] access token options, to pass to the AccessToken object
     # @param [Class] class of access token for easier subclassing OAuth2::AccessToken
-    # @return [AccessToken] the initalized AccessToken
+    # @return [AccessToken] the initialized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       params = Authenticator.new(id, secret, options[:auth_scheme]).apply(params)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'logger'
 

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   class Error < StandardError
     attr_reader :response, :code, :description

--- a/lib/oauth2/mac_token.rb
+++ b/lib/oauth2/mac_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'digest'
 require 'openssl'

--- a/lib/oauth2/mac_token.rb
+++ b/lib/oauth2/mac_token.rb
@@ -19,7 +19,7 @@ module OAuth2
 
     attr_reader :secret, :algorithm
 
-    # Initalize a MACToken
+    # Initialize a MACToken
     #
     # @param [Client] client the OAuth2::Client instance
     # @param [String] token the Access Token value

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'multi_json'
 require 'multi_xml'
 require 'rack'

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -43,7 +43,7 @@ module OAuth2
     #
     # @param [Faraday::Response] response The Faraday response instance
     # @param [Hash] opts options in which to initialize the instance
-    # @option opts [Symbol] :parse (:automatic) how to parse the response body.  one of :query (for x-www-form-urlencoded),
+    # @option opts [Symbol] :parse (:automatic) how to parse the response body. One of :query (for x-www-form-urlencoded),
     #   :json, or :automatic (determined by Content-Type response header)
     def initialize(response, opts = {})
       @response = response

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jwt'
 
 module OAuth2

--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   module Strategy
     # The Authorization Code Strategy

--- a/lib/oauth2/strategy/base.rb
+++ b/lib/oauth2/strategy/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   module Strategy
     class Base

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   module Strategy
     # The Client Credentials Strategy

--- a/lib/oauth2/strategy/implicit.rb
+++ b/lib/oauth2/strategy/implicit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   module Strategy
     # The Implicit Strategy

--- a/lib/oauth2/strategy/password.rb
+++ b/lib/oauth2/strategy/password.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   module Strategy
     # The Resource Owner Password Credentials Authorization Strategy

--- a/lib/oauth2/version.rb
+++ b/lib/oauth2/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OAuth2
   module Version
   module_function

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
@@ -13,11 +15,11 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com']
-  spec.files         = %w(.document CONTRIBUTING.md LICENSE.md README.md oauth2.gemspec) + Dir['lib/**/*.rb']
+  spec.files         = %w[.document CONTRIBUTING.md LICENSE.md README.md oauth2.gemspec] + Dir['lib/**/*.rb']
   spec.homepage      = 'http://github.com/intridea/oauth2'
-  spec.licenses      = %w(MIT)
+  spec.licenses      = %w[MIT]
   spec.name          = 'oauth2'
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
   spec.required_rubygems_version = '>= 1.3.5'
   spec.summary       = 'A Ruby wrapper for the OAuth 2.0 protocol.'
   spec.version       = OAuth2::Version

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION >= '1.9'
   require 'simplecov'
   require 'coveralls'

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -53,7 +53,7 @@ describe AccessToken do
       expect(hash).to eq(hash_before)
     end
 
-    it 'initalizes with a form-urlencoded key/value string' do
+    it 'initializes with a form-urlencoded key/value string' do
       kvform = "access_token=#{token}&expires_at=#{Time.now.to_i + 200}&foo=bar"
       target = AccessToken.from_kvform(client, kvform)
       assert_initialized_token(target)

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe AccessToken do

--- a/spec/oauth2/authenticator_spec.rb
+++ b/spec/oauth2/authenticator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Authenticator do

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 require 'helper'
 require 'nkf'
 
@@ -93,7 +95,7 @@ describe OAuth2::Client do
     end
   end
 
-  %w(authorize token).each do |url_type|
+  %w[authorize token].each do |url_type|
     describe ":#{url_type}_url option" do
       it "defaults to a path of /oauth/#{url_type}" do
         expect(subject.send("#{url_type}_url")).to eq("https://api.example.com/oauth/#{url_type}")
@@ -215,7 +217,7 @@ describe OAuth2::Client do
       expect(response.error).not_to be_nil
     end
 
-    %w(/unauthorized /conflict /error /different_encoding /ascii_8bit_encoding).each do |error_path|
+    %w[/unauthorized /conflict /error /different_encoding /ascii_8bit_encoding].each do |error_path|
       it "raises OAuth2::Error on error response to path #{error_path}" do
         expect { subject.request(:get, error_path) }.to raise_error(OAuth2::Error)
       end

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe MACToken do

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Response do

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Strategy::Assertion do
@@ -28,7 +30,7 @@ describe OAuth2::Strategy::Assertion do
     end
   end
 
-  %w(json formencoded).each do |mode|
+  %w[json formencoded].each do |mode|
     describe "#get_token (#{mode})" do
       before do
         @mode = mode

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'helper'
 
@@ -71,7 +72,7 @@ describe OAuth2::Strategy::AuthCode do
     end
   end
 
-  %w(json formencoded from_facebook).each do |mode|
+  %w[json formencoded from_facebook].each do |mode|
     [:get, :post].each do |verb|
       describe "#get_token (#{mode}, access_token_method=#{verb}" do
         before do

--- a/spec/oauth2/strategy/base_spec.rb
+++ b/spec/oauth2/strategy/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Strategy::Base do

--- a/spec/oauth2/strategy/client_credentials_spec.rb
+++ b/spec/oauth2/strategy/client_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Strategy::ClientCredentials do
@@ -37,7 +39,7 @@ describe OAuth2::Strategy::ClientCredentials do
     end
   end
 
-  %w(json formencoded).each do |mode|
+  %w[json formencoded].each do |mode|
     [:basic_auth, :request_body].each do |auth_scheme|
       describe "#get_token (#{mode}) (#{auth_scheme})" do
         before do

--- a/spec/oauth2/strategy/implicit_spec.rb
+++ b/spec/oauth2/strategy/implicit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Strategy::Implicit do

--- a/spec/oauth2/strategy/password_spec.rb
+++ b/spec/oauth2/strategy/password_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'helper'
 
 describe OAuth2::Strategy::Password do
@@ -25,7 +27,7 @@ describe OAuth2::Strategy::Password do
     end
   end
 
-  %w(json formencoded).each do |mode|
+  %w[json formencoded].each do |mode|
     describe "#get_token (#{mode})" do
       before do
         @mode = mode


### PR DESCRIPTION
Since Rubocop release 0.48 the code style checks no longer pass on Travis

This PR was created basically by running `$ rubocop -a` and `$ rubocop --auto-gen-config`.

The rule for `Style/MixinGrouping` looks like it's buggy. There are already some PRs to fix it (https://github.com/bbatsov/rubocop/pull/4177, https://github.com/bbatsov/rubocop/pull/4176), but I thought it would be best to exclude it via the todo-file. Maybe this file can be removed once Rubocop 0.48.1 is released.

Also fixed some typos.