### PR TITLE
The gem should allow minor versions of Faraday releases

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
+  spec.add_dependency 'faraday', ['>= 0.8', '~> 0.12']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
A gem should play nice with other gems in the Gemfile as much as possible.

Faraday is not breaking compatibility between minor releases, and there are many packages out there using faraday. Requiring faraday "less than the next minor release" means there's now way to upgrade Faraday in an app unless oauth2 releases a new gem each time which is a little extreme.

Thanks