### PR TITLE
Allow faraday 0.12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
-- No significant changes.
+- Add support for Faraday 0.12 (@rhymes, @josephpage)
 
 ## [1.3.0] - 2016-12-28
 

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 0.13']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
Faraday 0.12.0 was released 13 ago : https://github.com/lostisland/faraday/releases

⚠️ *Faraday is no more compatible with Ruby 1.8.7 since [0.10.0](https://github.com/lostisland/faraday/releases/tag/v0.10.0).*