### PR TITLE
Loosen version restriction of Farday to allow new minor versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'faraday', '~> 0.9.2', :platforms => [:jruby_18, :ruby_18]
-gem 'jwt', '< 1.5.2', :platforms => [:jruby_18, :ruby_18]
 gem 'rake', '< 11.0'
 gem 'rdoc', '~> 4.2.2'
 

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
+  spec.add_dependency 'faraday', ['>= 0.8', '~> 0.12']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -172,6 +172,8 @@ describe OAuth2::Client do
 
     it 'outputs to $stdout when OAUTH_DEBUG=true' do
       allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
+      allow(ENV).to receive(:[]).with('https_proxy').and_return(nil)
+      allow(ENV).to receive(:[]).with('HTTPS_PROXY').and_return(nil)
       allow(ENV).to receive(:[]).with('OAUTH_DEBUG').and_return('true')
       output = capture_output do
         subject.request(:get, '/success')


### PR DESCRIPTION
Based off #301 but with changes to `Gemfile` to make CI pass.