### PR TITLE
Updated faraday dependency

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.12']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 1.0']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'


### PR DESCRIPTION
To use latest and always latest faraday to avoid any http bugs that were fixed in faraday library. 